### PR TITLE
GitExtensions installer no longer installs Git or KDiff3

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,6 @@
   * Windows Explorer integration for Git
   * Visual Studio (2010/2012/2013/2015/2017) plugin ([download](https://marketplace.visualstudio.com/items?itemName=HenkWesthuis.GitExtensions))
   * Feature rich user interface for Git
-  * Single installer installs Git for Windows, GitExtensions and the mergetool KDiff3
   * 32bit and 64bit support
 
 ## Video Tutorial


### PR DESCRIPTION
For more information on the reasoning behind removing these features see GE Issue #4515 and GE PR #4930.
https://github.com/gitextensions/gitextensions/issues/4515
https://github.com/gitextensions/gitextensions/pull/4930