### PR TITLE
Remove /en/latest from Doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repo contains the source for the Git Extensions website at http://gitextensions.github.io/.
 
-The site is mostly a placeholder, more up to date info at https://github.com/gitextensions/gitextensions and more details at [online manual](https://git-extensions-documentation.readthedocs.org/en/latest/)
+The site is mostly a placeholder, more up to date info at https://github.com/gitextensions/gitextensions and more details at [online manual](https://git-extensions-documentation.readthedocs.org/)
 
 The process to troubleshoot updates is TBD.

--- a/index.md
+++ b/index.md
@@ -1,32 +1,42 @@
-  * [Online manual](https://git-extensions-documentation.readthedocs.org/en/latest/)
+  * [Online manual](https://git-extensions-documentation.readthedocs.org/)
   * [Issue tracker](http://github.com/gitextensions/gitextensions/issues)
   * [Our gitter channel](https://gitter.im/gitextensions/gitextensions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
   * [Donate via OpenCollective](https://opencollective.com/gitextensions)
 
 ## Features
+
   * Windows Explorer integration for Git
   * Visual Studio (2015/2017/2019) plugin ([download](https://marketplace.visualstudio.com/items?itemName=HenkWesthuis.GitExtensions))
   * Feature rich user interface for Git
 
 ## View Commit Log
+
 The full commit history can be browsed. Branches are shown using a graph which highlights commits that are included in the current revision.
 
 ![Commit Log](images/commitlog205.png)
 
 ## File History
+
 Explore the history of single files. Renamed and moved files are matched and shown in a single history. You do not need to mark files as renamed/moved. The system detects renamed files automatically.
 
 ![File History](images/FileHistory205.png)
 
 ## Blame
+
 Find the last person that edited a specific part of a file. Double click on the line shows the commit and allows you to drill-down to other files.
 
 ![Blame](images/Blame205.png)
 
 ## Multi Platform
+
 Version 2.x of Git Extensions runs on multiple platforms using Mono.
 
 ![Ubuntu](images/GitExtensionsUbuntu205.png)
 
 ## Active Community
+
 The active community of Git Extensions is supporting Git Extensions since 2008.
+
+More information in the [Git repo](http://github.com/gitextensions/gitextensions/issues).
+
+Generated from the following [Git repo](https://github.com/gitextensions/gitextensions.github.io).


### PR DESCRIPTION
Requests are directed to / anyway

See discussion in https://github.com/gitextensions/GitExtensionsDoc/issues/131